### PR TITLE
3 fix ndcg computation of IDCG

### DIFF
--- a/qual.py
+++ b/qual.py
@@ -10,9 +10,9 @@ def rr(grades, n=0):
     :param n: A number indicating how far down the list to go before giving up
     :return: A number between 1.0 and 0.0 indicating how far up the list the relevant document was found
     """
-    if n > len(grades):
+    if n == 0:
         n = len(grades)
-
+    n = min(n, len(grades))
     for i in range(0, n):
         if grades[i] > 0.0:
             return float(1.0 / (i + 1.0))
@@ -44,7 +44,7 @@ def err(grades, n=0):
     """
     if n == 0:
         n = len(grades)
-    n = min(n, len(grades)
+    n = min(n, len(grades))
     ERR = 0
     trustBank = 1 # In a way the users "trustBank"
     for i in range(0,n):
@@ -110,7 +110,7 @@ def dcg(grades, n=0):
     """
     if n == 0:
         n = len(grades)
-    n = min(n, len(grades)
+    n = min(n, len(grades))
     from math import log
     dcg = 0
     for i in range(0,n):
@@ -123,7 +123,7 @@ def dcgWConfs(grades, confs, midGrade=2.0, n=0):
         raise ValueError("dcgWConfs needs same number of grades as confs")
     if n == 0:
         n = len(grades)
-    n = min(n, len(grades)
+    n = min(n, len(grades))
     from math import log
     dcg = 0
     for i in range(0,n):

--- a/qual.py
+++ b/qual.py
@@ -137,7 +137,7 @@ def dcgWConfs(grades, confs, midGrade=2.0, n=0):
     return dcg
 
 
-def ndcg(grades, n=0):
+def ndcg(grades, rels, n=0):
     """
     Normalized Discounted Cumulative Gain
     https://en.wikipedia.org/wiki/Discounted_cumulative_gain#Normalized_DCG
@@ -146,11 +146,15 @@ def ndcg(grades, n=0):
     at the top and lower rated docs at the bottom.
 
     :param grades: A list of numbers indicating how relevant the corresponding document was at that position in the list
+    :param rels: A list of numbers containing all of the relevance judgements, for computing the ideal DCG. May be just the non-zero values.
     :param n: A number indicating the maximum number of positions to consider
     :return: A number between 1.0 and 0.0 indicating how close to the ideal ordering the docs are (higher is better)
     """
+    if n == 0:
+        n = len(grades)
+    n = min(n, len(grades))
     _dcg = dcg(grades, n=n)
-    _idcg = dcg(sorted(grades, reverse=True), n=n)
+    _idcg = dcg(sorted(rels, reverse=True), n=n)
     if _idcg > 0.0:
         return _dcg / _idcg
     else:

--- a/qual.py
+++ b/qual.py
@@ -42,10 +42,9 @@ def err(grades, n=0):
     :param max_grade: A float indicating the maximum grade a doc can get
     :return: A number between 1.0 and 0.0 indicating how good the results were (higher is better)
     """
-    if n > len(grades):
-        raise ValueError("err@%s cannot be calculated with %s grades" % (n, len(grades)))
     if n == 0:
         n = len(grades)
+    n = min(n, len(grades)
     ERR = 0
     trustBank = 1 # In a way the users "trustBank"
     for i in range(0,n):
@@ -109,10 +108,9 @@ def dcg(grades, n=0):
     :param n: A number indicating the maximum number of positions to consider
     :return: A number >= 0.0 indicating how the result set should be judged
     """
-    if n > len(grades):
-        raise ValueError("dcg@%s cannot be calculated with %s grades" % (n, len(grades)))
     if n == 0:
         n = len(grades)
+    n = min(n, len(grades)
     from math import log
     dcg = 0
     for i in range(0,n):
@@ -123,10 +121,9 @@ def dcg(grades, n=0):
 def dcgWConfs(grades, confs, midGrade=2.0, n=0):
     if len(grades) != len(confs):
         raise ValueError("dcgWConfs needs same number of grades as confs")
-    if n > len(grades) or n > len(confs):
-        raise ValueError("dcg@%s cannot be calculated with %s grades" % (n, len(grades)))
     if n == 0:
         n = len(grades)
+    n = min(n, len(grades)
     from math import log
     dcg = 0
     for i in range(0,n):


### PR DESCRIPTION
Closes #3 by changing dcg to take a second list parameter, the list of relevance judgment values for all documents (not just the documents in grades). This will break existing usages.